### PR TITLE
Fix bug where edit command allows duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/_markbind/logs/
 
 # Files generated in exports directory
 /exports/*
+/imports/*

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -83,7 +83,7 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        if (!personToEdit.isSamePerson(editedPerson) || model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -83,13 +83,26 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) || model.hasPerson(editedPerson)) {
+        if (hasDuplicate(model, personToEdit, editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+    }
+
+    /**
+     * Checks whether editing this person would result in a duplicate in the provided model
+     * @param model model
+     * @param personToEdit The person object from the model to be edited
+     * @param editedPerson The proposed edited person
+     * @return true if the edit will result in a duplicate in the model
+     */
+    private static boolean hasDuplicate(Model model, Person personToEdit, Person editedPerson) {
+        return model.getAddressBook().getPersonList().stream()
+                .filter(p -> p != personToEdit)
+                .anyMatch(p -> p.isSamePerson(editedPerson));
     }
 
     /**


### PR DESCRIPTION
Resolved the issue by checking whether the proposed edit will result in the same phone number or email with any other contact in the model.

Fixes #221
Fixes #220 
Fixes #219 
Fixes #217 
Fixes #199 
Fixes #198 
Fixes #196 